### PR TITLE
Use the latest macOS runner

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -21,7 +21,7 @@ jobs:
       - run: "packer validate ."
 
   build:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     needs: validate
 
     steps:


### PR DESCRIPTION
Manually installing VirtualBox (`brew install --cask virtualbox`) is not necessary.  The runner already has VirtualBox installed, it is just not in the README.

https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md

Fix #18