### PR TITLE
Remove hyphen from BRANCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Below is a sample `variables.pkrvars.hcl` file:
 
 ```hcl
 arch            = "amd64"
-branch          = "-RELEASE"
+branch          = "RELEASE"
 build_date      = ""
 cpus            = 1
 directory       = "releases"
@@ -123,20 +123,20 @@ The following variables can be set:
 -   `revision` is the FreeBSD revision number.  _Default:_ `13.2`
 
 -   `branch` used in conjunction with `build_date`, `git_commit` and
-    `directory`.  _Default:_ `-RELEASE`
+    `directory`.  _Default:_ `RELEASE`
 
     See FreeBSD's [Release Branches] for more information.  Possible
     values are:
 
-    | Branch                  | Directory   |
-    | ------                  | ---------   |
-    | `-CURRENT`              | `snapshots` |
-    | `-STABLE`               | `snapshots` |
-    | `-ALPHA1`, `-ALPHA2`, … | `snapshots` |
-    | `-PRERELEASE`           | `snapshots` |
-    | `-BETA1`, `-BETA2`, …   | `releases`  |
-    | `-RC1`, `-RC2`, …       | `releases`  |
-    | `-RELEASE`              | `releases`  |
+    | Branch                | Directory   |
+    | ------                | ---------   |
+    | `CURRENT`             | `snapshots` |
+    | `STABLE`              | `snapshots` |
+    | `ALPHA1`, `ALPHA2`, … | `snapshots` |
+    | `PRERELEASE`          | `snapshots` |
+    | `BETA1`, `BETA2`, …   | `releases`  |
+    | `RC1`, `RC2`, …       | `releases`  |
+    | `RELEASE`             | `releases`  |
 
 -   `arch` is the target architecture (`i386` or `amd64`).  _Default:_
     `amd64`

--- a/packer.pkr.hcl
+++ b/packer.pkr.hcl
@@ -3,15 +3,15 @@ source "virtualbox-iso" "freebsd" {
   boot_wait               = "10s"
   cpus                    = "${var.cpus}"
   disk_size               = "${var.disk_size}"
-  export_opts             = ["--manifest", "--vsys", "0", "--product", "FreeBSD-${var.revision}${var.branch}-${var.arch}${var.build_date}", "--producturl", "https://www.freebsd.org", "--description", "FreeBSD is an operating system used to power modern servers, desktops, and embedded platforms.", "--version", "${var.revision}${var.branch}"]
+  export_opts             = ["--manifest", "--vsys", "0", "--product", "FreeBSD-${var.revision}-${var.branch}-${var.arch}${var.build_date}", "--producturl", "https://www.freebsd.org", "--description", "FreeBSD is an operating system used to power modern servers, desktops, and embedded platforms.", "--version", "${var.revision}-${var.branch}"]
   guest_additions_mode    = "disable"
   guest_os_type           = "${var.guest_os_type}"
   hard_drive_interface    = "sata"
   headless                = true
   http_directory          = "http"
-  iso_checksum            = "file:${var.mirror}/${var.directory}/ISO-IMAGES/${var.revision}/CHECKSUM.SHA256-FreeBSD-${var.revision}${var.branch}-${var.arch}${var.build_date}${var.git_commit}"
+  iso_checksum            = "file:${var.mirror}/${var.directory}/ISO-IMAGES/${var.revision}/CHECKSUM.SHA256-FreeBSD-${var.revision}-${var.branch}-${var.arch}${var.build_date}${var.git_commit}"
   iso_interface           = "sata"
-  iso_urls                = ["iso/FreeBSD-${var.revision}${var.branch}-${var.arch}${var.build_date}${var.git_commit}-disc1.iso", "${var.mirror}/${var.directory}/ISO-IMAGES/${var.revision}/FreeBSD-${var.revision}${var.branch}-${var.arch}${var.build_date}${var.git_commit}-disc1.iso"]
+  iso_urls                = ["iso/FreeBSD-${var.revision}-${var.branch}-${var.arch}${var.build_date}${var.git_commit}-disc1.iso", "${var.mirror}/${var.directory}/ISO-IMAGES/${var.revision}/FreeBSD-${var.revision}-${var.branch}-${var.arch}${var.build_date}${var.git_commit}-disc1.iso"]
   memory                  = "${var.memory}"
   shutdown_command        = "poweroff"
   ssh_password            = "vagrant"
@@ -32,7 +32,7 @@ build {
   }
 
   post-processor "vagrant" {
-    output               = "builds/FreeBSD-${var.revision}${var.branch}-${var.arch}${var.build_date}${var.git_commit}.box"
+    output               = "builds/FreeBSD-${var.revision}-${var.branch}-${var.arch}${var.build_date}${var.git_commit}.box"
     vagrantfile_template = "vagrantfile.tpl"
   }
 }

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -5,7 +5,7 @@ variable "arch" {
 
 variable "branch" {
   type    = string
-  default = "-RELEASE"
+  default = "RELEASE"
 }
 
 variable "build_date" {

--- a/variables.pkrvars.hcl.sample
+++ b/variables.pkrvars.hcl.sample
@@ -1,5 +1,5 @@
 arch            = "amd64"
-branch          = "-RELEASE"
+branch          = "RELEASE"
 build_date      = ""
 cpus            = 1
 directory       = "releases"


### PR DESCRIPTION
Follow `sys/conf/newvers.sh` conventions and remove the hyphen from the var itself.

Fix #22.