### PR TITLE
ntpdate: no server suitable for synchronization found

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -29,3 +29,5 @@ jobs:
 
     - name: Build the box
       run: packer build .
+      env:
+        ntpdate_hosts: ntp.ubuntu.com

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,16 +1,8 @@
 #!/bin/sh
 set -e
 
-# XXX test
-sysrc ntpdate_hosts="ntp.ubuntu.com"
-# XXX test
-
 # Set the time
 service ntpdate onestart || true
-
-# XXX test
-sysrc ntpdate_hosts=""
-# XXX test
 
 # Update FreeBSD
 freebsd-update --not-running-from-cron fetch install || true

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,8 +1,16 @@
 #!/bin/sh
 set -e
 
+# XXX test
+sysrc ntpdate_hosts="ntp.ubuntu.com"
+# XXX test
+
 # Set the time
 service ntpdate onestart || true
+
+# XXX test
+sysrc ntpdate_hosts=""
+# XXX test
 
 # Update FreeBSD
 freebsd-update --not-running-from-cron fetch install || true


### PR DESCRIPTION
It seems that Azure is blocking NTP requests. According to the documentation, `ntp.ubuntu.com` should be allowed.

Try syncing to this server instead.