### PR TITLE
Use Linux runners exclusively

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -41,7 +41,9 @@ jobs:
           echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] http://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo apt-get update
-          sudo apt-get install -y vagrant virtualbox-6.1
+          sudo apt-get install -y vagrant virtualbox-7.0
+          sudo apt-get install -y cpu-checker
+          sudo kvm-ok
 
       - name: Initialize Packer
         run: packer init .

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -36,12 +36,12 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-2016-keyring.gpg
+          wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-2016.gpg
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016-keyring.gpg] http://virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] http://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt update
-          sudo apt install -y vagrant virtualbox-7.0
+          sudo apt-get update
+          sudo apt-get install -y vagrant virtualbox-6.1
 
       - name: Initialize Packer
         run: packer init .

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -40,8 +40,8 @@ jobs:
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016-keyring.gpg] http://virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt-get -y update
-          sudo apt-get -y install vagrant virtualbox-7.0
+          sudo apt update
+          sudo apt install -y vagrant virtualbox-7.0
 
       - name: Initialize Packer
         run: packer init .

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -36,10 +36,12 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get install virtualbox
+          wget -O- https://www.virtualbox.org/download/oracle_vbox.asc | sudo gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-keyring.gpg
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-keyring.gpg] http://virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt update && sudo apt install vagrant
+          sudo apt-get -y update
+          sudo apt-get -y install vagrant virtualbox-7.0
 
       - name: Initialize Packer
         run: packer init .

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -36,9 +36,9 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          wget -O- https://www.virtualbox.org/download/oracle_vbox.asc | sudo gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-keyring.gpg
+          wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-2016-keyring.gpg
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-keyring.gpg] http://virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016-keyring.gpg] http://virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo apt-get -y update
           sudo apt-get -y install vagrant virtualbox-7.0

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -15,19 +15,36 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Validate Template
+      - name: Setup Packer
         uses: hashicorp/setup-packer@main
 
-      - run: "packer validate ."
+      - name: Initialize Packer
+        run: packer init .
+        env:
+          PACKER_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Validate Template
+        run: packer validate .
 
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: validate
 
     steps:
-    - uses: actions/checkout@v3
+      - name: Checkout Repository
+        uses: actions/checkout@v3
 
-    - name: Build the box
-      run: packer build .
-      env:
-        ntpdate_hosts: ntp.ubuntu.com
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install virtualbox
+          wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt update && sudo apt install vagrant
+
+      - name: Initialize Packer
+        run: packer init .
+        env:
+          PACKER_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Build the Box
+        run: packer -machine-readable build .

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ To create a box:
         $ git clone https://github.com/jlduran/packer-FreeBSD.git
         $ cd packer-FreeBSD
 
-2.  Build the box:
+2.  Initialize packer:
+
+        $ packer init .
+
+3.  Build the box:
 
         $ packer build .
 
-3.  Add it to the list of Vagrant boxes.  See
+4.  Add it to the list of Vagrant boxes.  See
     [Handling `.iso` and `.box` files](#handling-iso-and-box-files) for
     more information.
 

--- a/packer.pkr.hcl
+++ b/packer.pkr.hcl
@@ -36,3 +36,16 @@ build {
     vagrantfile_template = "vagrantfile.tpl"
   }
 }
+
+packer {
+  required_plugins {
+    vagrant = {
+      source  = "github.com/hashicorp/vagrant"
+      version = "~> 1"
+    }
+    virtualbox = {
+      source  = "github.com/hashicorp/virtualbox"
+      version = "~> 1"
+    }
+  }
+}


### PR DESCRIPTION
In preparation for the addition of other architectures and builders.